### PR TITLE
Mongodb 6.x compat

### DIFF
--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -119,8 +119,7 @@ Queue.prototype.get = function(opts, callback) {
         }
     }
 
-    self.col.findOneAndUpdate(query, update, { sort: sort, returnDocument : 'after' }).then((result) => {
-        var msg = result.value
+    self.col.findOneAndUpdate(query, update, { sort: sort, returnDocument : 'after' }).then((msg) => {
         if (!msg) return callback()
 
         // convert to an external representation
@@ -173,10 +172,10 @@ Queue.prototype.ping = function(ack, opts, callback) {
         }
     }
     self.col.findOneAndUpdate(query, update, { returnDocument : 'after' }).then((msg) => {
-        if ( !msg.value ) {
+        if ( !msg ) {
             return callback(new Error("Queue.ping(): Unidentified ack  : " + ack))
         }
-        callback(null, '' + msg.value._id)
+        callback(null, '' + msg._id)
     }).catch((err) => callback(err))
 }
 
@@ -194,10 +193,10 @@ Queue.prototype.ack = function(ack, callback) {
         }
     }
     self.col.findOneAndUpdate(query, update, { returnDocument : 'after' }).then((msg) => {
-        if ( !msg.value ) {
+        if ( !msg ) {
             return callback(new Error("Queue.ack(): Unidentified ack : " + ack))
         }
-        callback(null, '' + msg.value._id)
+        callback(null, '' + msg._id)
     }).catch((err) => callback(err))
 }
 

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -38,7 +38,7 @@ function Queue(db, name, opts) {
         throw new Error("mongodb-queue: provide a queue name")
     }
     opts = opts || {}
-    
+
     this.db = db
     this.name = name
     this.col = db.collection(name)
@@ -104,7 +104,7 @@ Queue.prototype.get = function(opts, callback) {
 
     var visibility = opts.visibility || self.visibility
     var query = {
-        deleted : null,
+        deleted: { $exists: false },
         visible : { $lte : now() },
     }
     var sort = {
@@ -163,7 +163,7 @@ Queue.prototype.ping = function(ack, opts, callback) {
     var query = {
         ack     : ack,
         visible : { $gt : now() },
-        deleted : null,
+        deleted: { $exists: false },
     }
     var update = {
         $set : {
@@ -184,7 +184,7 @@ Queue.prototype.ack = function(ack, callback) {
     var query = {
         ack     : ack,
         visible : { $gt : now() },
-        deleted : null,
+        deleted: { $exists: false },
     }
     var update = {
         $set : {
@@ -219,7 +219,7 @@ Queue.prototype.size = function(callback) {
     var self = this
 
     var query = {
-        deleted : null,
+        deleted: { $exists: false },
         visible : { $lte : now() },
     }
 
@@ -232,7 +232,7 @@ Queue.prototype.inFlight = function(callback) {
     var query = {
         ack     : { $exists : true },
         visible : { $gt : now() },
-        deleted : null,
+        deleted: { $exists: false },
     }
 
     self.col.countDocuments(query).then((count) => callback(null, count)).catch((err) => callback(err))

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -39,7 +39,6 @@ function Queue(db, name, opts) {
     }
     opts = opts || {}
 
-    this.db = db
     this.name = name
     this.col = db.collection(name)
     this.visibility = opts.visibility || 30
@@ -52,7 +51,6 @@ function Queue(db, name, opts) {
 }
 
 Queue.prototype.createIndexes = function(callback) {
-    console.log('index');
     var self = this
 
     self.col.createIndex({ deleted : 1, visible : 1 }).then((indexname) => {

--- a/mongodb-queue.js
+++ b/mongodb-queue.js
@@ -38,7 +38,8 @@ function Queue(db, name, opts) {
         throw new Error("mongodb-queue: provide a queue name")
     }
     opts = opts || {}
-
+    
+    this.db = db
     this.name = name
     this.col = db.collection(name)
     this.visibility = opts.visibility || 30

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,29 +10,31 @@
       "license": "MIT",
       "devDependencies": {
         "async": "^2.6.2",
-        "mongodb": "^5.7.0",
+        "mongodb": "^6.12.0",
         "tape": "^4.10.1"
       }
     },
-    "node_modules/@types/node": {
-      "version": "20.4.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
-      "dev": true
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+      "dev": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
     },
     "node_modules/@types/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
       "dev": true
     },
     "node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -62,12 +64,12 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
+      "integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
       "dev": true,
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/concat-map": {
@@ -210,7 +212,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-callable": {
       "version": "1.1.4",
@@ -264,8 +268,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -286,33 +289,35 @@
       "dev": true
     },
     "node_modules/mongodb": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.7.0.tgz",
-      "integrity": "sha512-zm82Bq33QbqtxDf58fLWBwTjARK3NSvKYjyz997KSy6hpat0prjeX/kxjbPVyZY60XYPDNETaHkHJI2UCzSLuw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
+      "integrity": "sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==",
       "dev": true,
       "dependencies": {
-        "bson": "^5.4.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.1",
+        "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "saslprep": "^1.0.3"
+        "node": ">=16.20.1"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.201.0",
-        "@mongodb-js/zstd": "^1.1.0",
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
           "optional": true
         },
         "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
           "optional": true
         },
         "kerberos": {
@@ -323,17 +328,20 @@
         },
         "snappy": {
           "optional": true
+        },
+        "socks": {
+          "optional": true
         }
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
       "dev": true,
       "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
       }
     },
     "node_modules/object-inspect": {
@@ -376,9 +384,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -402,24 +410,13 @@
         "through": "~2.3.4"
       }
     },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -430,6 +427,8 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -444,7 +443,6 @@
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -494,15 +492,15 @@
       "dev": true
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
       "dev": true,
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/webidl-conversions": {
@@ -515,16 +513,16 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
       "dev": true,
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/wrappy": {
@@ -535,25 +533,27 @@
     }
   },
   "dependencies": {
-    "@types/node": {
-      "version": "20.4.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
-      "dev": true
+    "@mongodb-js/saslprep": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+      "dev": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
     },
     "@types/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
       "dev": true
     },
     "@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -583,9 +583,9 @@
       }
     },
     "bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
+      "integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
       "dev": true
     },
     "concat-map": {
@@ -710,7 +710,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -752,8 +754,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -771,25 +772,24 @@
       "dev": true
     },
     "mongodb": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.7.0.tgz",
-      "integrity": "sha512-zm82Bq33QbqtxDf58fLWBwTjARK3NSvKYjyz997KSy6hpat0prjeX/kxjbPVyZY60XYPDNETaHkHJI2UCzSLuw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
+      "integrity": "sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==",
       "dev": true,
       "requires": {
-        "bson": "^5.4.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "saslprep": "^1.0.3",
-        "socks": "^2.7.1"
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.1",
+        "mongodb-connection-string-url": "^3.0.0"
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
       "dev": true,
       "requires": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
       }
     },
     "object-inspect": {
@@ -826,9 +826,9 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
     },
     "resolve": {
@@ -849,27 +849,21 @@
         "through": "~2.3.4"
       }
     },
-    "saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "sparse-bitfield": "^3.0.3"
-      }
-    },
     "smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -880,7 +874,6 @@
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
       }
@@ -924,12 +917,12 @@
       "dev": true
     },
     "tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.0"
       }
     },
     "webidl-conversions": {
@@ -939,12 +932,12 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
       "dev": true,
       "requires": {
-        "tr46": "^3.0.0",
+        "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "async": "^2.6.2",
-    "mongodb": "^5.7.0",
+    "mongodb": "^6.12.0",
     "tape": "^4.10.1"
   },
   "homepage": "https://github.com/chilts/mongodb-queue",


### PR DESCRIPTION
MongoDB 6 introduced the following change:
```
findOneAndX family of methods will now return only the found document or null by default (includeResultMetadata is false by default)
```

Drop the need for the wrapper in the codebase as it doesn't use it.